### PR TITLE
Add customization for persistence, server timezone and TCP/UDP services generation

### DIFF
--- a/charts/openvpn-as/README.md
+++ b/charts/openvpn-as/README.md
@@ -68,18 +68,22 @@ The following tables list the configurable parameters of the openvpn-as chart an
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | openvpn.admin.password | string | `"passw0rd"` | Password for the initial super_user |
-| openvpn.admin.user | string | `"altmin"` | Username for the initial super_user |
+| openvpn.admin.user | string | `"altmin"` | Username for the initial super_user. **cannot be** `admin` |
 | openvpn.config | object | `{"vpn.client.routing.reroute_dns":"false","vpn.client.routing.reroute_gw":"false"}` | Config settings to apply to the openvpn-as server |
 | openvpn.ports.admin | int | `943` | Admin GUI port |
 | openvpn.ports.gui | int | `944` | Client GUI port |
 | openvpn.ports.tcp | int | `9443` | VPN TCP port |
 | openvpn.ports.udp | int | `1194` | VPN UDP port |
 | openvpn.users | list | `nil` | Additional users to create when non-existent `[{"user":"someuser","password":"somepassword"}]` |
+| openvpn.timezone | string | `"Europe/London"` | Server timezone |
 | persistence.accessMode | string | `"ReadWriteOnce"` | PVC Access Mode for volume |
 | persistence.annotations | object | `{}` | Annotations for the PVC |
 | persistence.enabled | bool | `true` | Enable persistence using PVC |
 | persistence.size | string | `"8Gi"` | PVC Storage Request for volume |
 | persistence.storageClass | string | `nil` | PVC Storage Class for volume |
+| persistence.existingClaimName | string | `nil` | To use an existing PVC Storage by its name instead of creating one |
+| persistence.backupSubpath | string | `"backup"` | To customize subpath for backups on PVC Storage |
+| persistence.licensesSubpath | string | `"licenses"` | To customize subpath for licenses on PVC Storage |
 | podAnnotations | object | `{}` | Map of annotations to add to the pods |
 | podSecurityContext.fsGroup | int | `1000` | Group ID for the pod |
 | replicaCount | int | `1` |  |
@@ -88,6 +92,8 @@ The following tables list the configurable parameters of the openvpn-as chart an
 | service.admin.type | string | `"ClusterIP"` | Kubernetes Service type for Admin GUI |
 | service.gui.type | string | `"ClusterIP"` | Kubernetes Service type for Client GUI |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type for VPN, generally this is "LoadBalancer" |
+| service.udp.enabled | bool | `true` | Create Service for UDP Traffic VPN |
+| service.tcp.enabled | bool | `true` | Create Service for TCP Traffic VPN |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Create ServiceAccount |
 | serviceAccount.name | string | `""` |  |

--- a/charts/openvpn-as/templates/deployment.yaml
+++ b/charts/openvpn-as/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - name: PGID
               value: "1000"
             - name: TZ
-              value: "Europe/London"
+              value: {{quote .Values.openvpn.timezone }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -72,9 +72,12 @@ spec:
             - name: init
               mountPath: /etc/cont-init.d/25-restore-backup
               subPath: 25-restore-backup
-            - name: backup
+            - name: persistence
               mountPath: /backup
-              subPath: backup
+              subPath: {{ .Values.persistence.backupSubpath }}
+            - name: persistence
+              mountPath: /usr/local/openvpn_as/etc/licenses/
+              subPath: {{ .Values.persistence.licensesSubpath }}
             - name: configure
               mountPath: /config/custom-cont-init.d
           resources:
@@ -88,9 +91,13 @@ spec:
           secret:
             secretName: {{ include "openvpn-as.fullname" . }}-configure
             defaultMode: 0777
-        - name: backup
+        - name: persistence
           persistentVolumeClaim:
+            {{- if .Values.persistence.existingClaimName }}
+            claimName: {{ .Values.persistence.existingClaimName }}
+            {{- else }}
             claimName: {{ include "openvpn-as.fullname" . }}-state
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openvpn-as/templates/pvc.yaml
+++ b/charts/openvpn-as/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.persistence.existingClaimName }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -16,4 +17,5 @@ spec:
       storage: {{ .Values.persistence.size | quote }}
 {{- if .Values.persistence.storageClass }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
 {{- end }}

--- a/charts/openvpn-as/templates/service.yaml
+++ b/charts/openvpn-as/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.tcp.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,6 +15,8 @@ spec:
   selector:
     {{- include "openvpn-as.selectorLabels" . | nindent 4 }}
 ---
+{{- end }}
+{{- if .Values.service.udp.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,3 +32,4 @@ spec:
       name: vpn-udp
   selector:
     {{- include "openvpn-as.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/openvpn-as/values.yaml
+++ b/charts/openvpn-as/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 
 openvpn:
+  timezone: Europe/London
   ports:
     # -- Admin GUI port
     admin: 943
@@ -21,7 +22,7 @@ openvpn:
     # host.name: vpn.example.com
 
   admin:
-    # -- Username for the initial super_user
+    # -- Username for the initial super_user. Cannot be `admin`
     user: altmin
     # -- Password for the initial super_user
     password: passw0rd
@@ -41,6 +42,12 @@ persistence:
   accessMode: "ReadWriteOnce"
   # -- PVC Storage Request for volume
   size: "8Gi"
+  # -- used when PVC already created before install
+  existingClaimName:
+  # -- Indicate another subpath for backup storage
+  backupSubpath: backup
+  # -- Indicate another subpath for licenses storage
+  licensesSubpath: licenses
 
 image:
   # -- Image repository
@@ -76,6 +83,10 @@ securityContext:
 service:
   # -- Kubernetes Service type for VPN, generally this is "LoadBalancer"
   type: ClusterIP
+  tcp:
+    enabled: true
+  udp:
+    enabled: true
   admin:
     # -- Kubernetes Service type for Admin GUI
     type: ClusterIP


### PR DESCRIPTION
Hello,

I was using your helm chart to setup a VPN for our company.
I noticed there were several points where I need to customize some of the components. I believe that many others could benefit from these changes as well since this chart makes openvpn-as already work out of the box.

I also noticed had a problem logging in on the Admin Web UI because I initially wanted to create a super_user with the name `admin` and I realised it was deleted in the configure-admin shell script after a bit of debugging. So I took liberty to indicate not to use the name `admin` in the docs.

Here is the, rather long, commit message:

feat(service): add option to enable/disable TCP/UDP services generation
feat(openvpn-as):
- add option to customize timezone
- add persistence for licenses
feat(docs): add sections for new functionalities and indicate that admin super_user cannot be admin