### PR TITLE
update for ingress-v1 support

### DIFF
--- a/charts/openvpn-as/Chart.yaml
+++ b/charts/openvpn-as/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openvpn-as
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.8
+version: 0.2.0
 appVersion: version-2.8.6-916f8e7d-ubuntu18
 maintainers:
   - email: dries@stenic.io

--- a/charts/openvpn-as/templates/ingress.admin.yaml
+++ b/charts/openvpn-as/templates/ingress.admin.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.admin.enabled -}}
 {{- $fullName := include "openvpn-as.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-admin
@@ -23,12 +19,18 @@ spec:
         - {{ .Values.ingress.admin.hostName | quote }}
       secretName: {{ .Values.ingress.admin.tls.secretName }}
   {{- end }}
+  {{- if .Values.ingress.admin.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.admin.ingressClassName }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.admin.hostName | quote }}
       http:
         paths:
           - path: "/"
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-admin
-              servicePort: {{ .Values.openvpn.ports.admin }}
+              service:
+                name: {{ $fullName }}-admin
+                port:
+                  number: {{ .Values.openvpn.ports.admin }}
   {{- end }}

--- a/charts/openvpn-as/templates/ingress.gui.yaml
+++ b/charts/openvpn-as/templates/ingress.gui.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.gui.enabled -}}
 {{- $fullName := include "openvpn-as.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-gui
@@ -13,7 +9,7 @@ metadata:
     {{- include "openvpn-as.labels" . | nindent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    {{- with .Values.ingress.admin.annotations }}
+    {{- with .Values.ingress.gui.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -23,12 +19,18 @@ spec:
         - {{ .Values.ingress.gui.hostName | quote }}
       secretName: {{ .Values.ingress.gui.tls.secretName }}
   {{- end }}
+  {{- if .Values.ingress.gui.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.gui.ingressClassName }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.gui.hostName | quote }}
       http:
         paths:
           - path: "/"
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-gui
-              servicePort: {{ .Values.openvpn.ports.gui }}
+              service:
+                name: {{ $fullName }}-gui
+                port:
+                  number: {{ .Values.openvpn.ports.gui }}
   {{- end }}

--- a/charts/openvpn-as/values.yaml
+++ b/charts/openvpn-as/values.yaml
@@ -93,6 +93,7 @@ ingress:
       # kubernetes.io/tls-acme: "true"
     # -- Host for the Client GUI
     hostName: client.openvpn.local
+    ingressClassName: # set ingressClassName here, or leave it unset
     tls:
       # -- Enable TLS configuration for the hostname defined at ingress.gui.hostname parameter
       enabled: true
@@ -106,6 +107,7 @@ ingress:
       # kubernetes.io/tls-acme: "true"
     # -- Host for the Admin GUI
     hostName: admin.openvpn.local
+    ingressClassName: # set ingressClassName here, or leave it unset
     tls:
       # -- Enable TLS configuration for the hostname defined at ingress.admin.hostname parameter
       enabled: true


### PR DESCRIPTION
This change is 99% focused on updating the Ingress to work with v1

I would like to say, I am so glad you published this, even if you have no intention of supporting it. (I don't know how you could support it, given the upstream images are not being published regularly for the past 3 months...)

I needed to add these minimal changes to get the openvpn-as server working on my Kubernetes environment.

One change is buried in here that is the 1% not focused on updating Ingress for conformance with `networking.k8s.io/v1` API:

https://github.com/stenic/helm-charts/compare/master...kingdonb:ingress-v1?expand=1#diff-7f0ea7c8021be7d5c964e7789b0422183f85f818f6b30dcb2286fdfe1a5cbd0eR12

I believe this was a typo, probably happened when this chart was cobbled together. It wasn't really in my way but I couldn't help myself when I found the error, I just fixed it.

Thanks again for publishing this! I don't know how you feel about jettisoning the IF statement that decides which API to use. I think it's easier to just say "v1 is GA, time to adopt it" and especially don't try to build both ingress syntaxes now that they have diverged. I bumped the minor rev on the chart to 0.2.0 which is meant to indicate for that item as a breaking change.

Anyway this change worked for me, feel free to merge it! If you can publish the new revision it would be helpful to me, but you've already been so much help today. Thanks again.